### PR TITLE
removes confirmation of changes if there are no changes

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -61,7 +61,13 @@ BestInPlaceEditor.prototype = {
   },
 
   abortIfConfirm : function () {
-    if (!this.useConfirm) {
+    var noChanges;
+    
+    if (this.oldValue && this.element.text()) {
+      noChanges = this.oldValue.trim() === this.element.text().trim()
+    }
+    
+    if (noChanges || !this.useConfirm) {
       this.abort();
       return;
     }


### PR DESCRIPTION
If a user doesn't change the text, should i confirm changes will be lost? There are no changes to confirm being lost so it seems like an extra alert for nothing.
